### PR TITLE
Enable `Try` on generated types.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust Nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          override: true
+          override: true          
 
       - name: Run tests
         run: |
           cargo clippy --all-targets --all-features
           cargo fmt
           cargo test
+          cargo +nightly test
+          cargo +nightly test --doc -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "enumizer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "paste",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enumizer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "simple macros for generating enums that are equivalent and convertible to standard library enums"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Add macro to enable usage of `Try` implementation on nightly for Option and Result aliases.

https://github.com/nihohit/enumizer/issues/3